### PR TITLE
If no path can be determined, open at system path as default.

### DIFF
--- a/src/OpenCommandLinePackage.cs
+++ b/src/OpenCommandLinePackage.cs
@@ -75,7 +75,7 @@ namespace MadsKristensen.OpenCommandLine
             if (_dte.Solution != null && !string.IsNullOrEmpty(_dte.Solution.FullName))
                 return Path.GetDirectoryName(_dte.Solution.FullName);
 
-            return null;
+            return Environment.GetFolderPath(Environment.SpecialFolder.System);
         }
 
         public static Project GetActiveProject()


### PR DESCRIPTION
Based on questions I'm seeing in the Q&A and also from my own experience the first time, I thought the tool didn't work because I didn't have a sln open.  Given that probably isn't going to be the case often, but with this change, at least it will open to the system directory if no current sln is open.