### PR TITLE
Expand environment variables and allow passing of "folderpath" to command line.

### DIFF
--- a/src/OpenCommandLinePackage.cs
+++ b/src/OpenCommandLinePackage.cs
@@ -40,8 +40,21 @@ namespace MadsKristensen.OpenCommandLine
                 return;
 
             Options options = GetDialogPage(typeof(Options)) as Options;
+            string command = options.Command;
+            string arguments = options.Arguments;
 
-            ProcessStartInfo start = new ProcessStartInfo(options.Command, options.Arguments);
+            if (options.ReplaceEnvironmentVariables)
+            {
+                command = Environment.ExpandEnvironmentVariables(options.Command);
+                arguments = Environment.ExpandEnvironmentVariables(options.Arguments);
+            }
+
+            if (!string.IsNullOrWhiteSpace(options.FolderPathReplacementToken))
+            {
+                arguments = arguments.Replace(options.FolderPathReplacementToken, folder);
+            }
+
+            ProcessStartInfo start = new ProcessStartInfo(command, arguments);
             start.WorkingDirectory = folder;
 
             System.Diagnostics.Process.Start(start);

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -16,6 +16,16 @@ namespace MadsKristensen.OpenCommandLine
         [DefaultValue("")]
         public string Arguments { get; set; }
 
+        [DisplayName("Folder path replacement token")]
+        [Description("If not empty, the token will be replaced verbatim in the command line.")]
+        [DefaultValue("$FolderPath$")]
+        public string FolderPathReplacementToken { get; set; }
+
+        [DisplayName("Replace environment variables")]
+        [Description("Replace environment variables in command and arguments.")]
+        [DefaultValue(true)]
+        public bool ReplaceEnvironmentVariables { get; set; }
+
         public override void LoadSettingsFromStorage()
         {
             base.LoadSettingsFromStorage();


### PR DESCRIPTION
Added options:
- Replace environment variables (%VAR%) in "command" and "arguments".
- Allow a special token-string in the arguments, that will be replaced with the target folder path (i.e. allow to pass the target folder other than by "Process.WorkingDirectory" only)