### PR TITLE
*.exe suffix to open PowerShell correctly when TFS 2013 Power Tools is installed

### DIFF
--- a/src/Options.cs
+++ b/src/Options.cs
@@ -7,7 +7,7 @@ namespace MadsKristensen.OpenCommandLine
     {
         [DisplayName("Command")]
         [Description("The command or filepath to an executable such as cmd.exe")]
-        [DefaultValue("cmd")]
+        [DefaultValue("cmd.exe")]
         [TypeConverter(typeof(CommandTypeConverter))]
         public string Command { get; set; }
 
@@ -36,7 +36,7 @@ namespace MadsKristensen.OpenCommandLine
             base.LoadSettingsFromStorage();
 
             if (string.IsNullOrEmpty(Command))
-                Command = "cmd";
+                Command = "cmd.exe";
         }
     }
 
@@ -49,7 +49,7 @@ namespace MadsKristensen.OpenCommandLine
 
         public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
         {
-            return new StandardValuesCollection(new[] { "cmd", "PowerShell" });
+            return new StandardValuesCollection(new[] { "cmd.exe", "powershell.exe" });
         }
     }
 }


### PR DESCRIPTION
When TFS 2013 Power Tools is installed, the folder "C:\Program Files (x86)\Microsoft Team Foundation Server 2013 Power Tools\PowerShell" is opened instead of powershell.exe

After adding the *.exe suffix, PowerShell is opened correctly.

![powershell](https://cloud.githubusercontent.com/assets/2670325/5875390/fc5f3704-a30c-11e4-98a6-1560e0ff6c57.jpg)

![powershell_exe](https://cloud.githubusercontent.com/assets/2670325/5875403/051f767e-a30d-11e4-8edf-e9aefeaa94f0.jpg)