### PR TITLE
Adding right-click support to various solution explorer hierarchy item types

### DIFF
--- a/src/OpenCommandLine.vsct
+++ b/src/OpenCommandLine.vsct
@@ -75,7 +75,22 @@
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_WEBPROJECT"/>
     </CommandPlacement>
     <CommandPlacement guid="guidOpenCommandLineCmdSet" id="ContextMenuGroup" priority="0x0600">
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_WEBFOLDER"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidOpenCommandLineCmdSet" id="ContextMenuGroup" priority="0x0600">
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_WEBITEMNODE"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidOpenCommandLineCmdSet" id="ContextMenuGroup" priority="0x0600">
       <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_SOLNNODE"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidOpenCommandLineCmdSet" id="ContextMenuGroup" priority="0x0600">
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_PROJNODE"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidOpenCommandLineCmdSet" id="ContextMenuGroup" priority="0x0600">
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_ITEMNODE"/>
+    </CommandPlacement>
+    <CommandPlacement guid="guidOpenCommandLineCmdSet" id="ContextMenuGroup" priority="0x0600">
+      <Parent guid="guidSHLMainMenu" id="IDM_VS_CTXT_FOLDERNODE"/>
     </CommandPlacement>
   </CommandPlacements>
 

--- a/src/Options.cs
+++ b/src/Options.cs
@@ -25,10 +25,10 @@ namespace MadsKristensen.OpenCommandLine
         public string FolderPathReplacementToken { get; set; }
 
         [Category("Settings")]
-		[DisplayName("Always open at solution level")]
-		[Description("Always open command prompt at the solution level.")]
-		[DefaultValue(false)]
-		public bool OpenSlnLevel { get; set; }
+        [DisplayName("Always open at solution level")]
+        [Description("Always open command prompt at the solution level.")]
+        [DefaultValue(false)]
+        public bool OpenSlnLevel { get; set; }
 
         public override void LoadSettingsFromStorage()
         {

--- a/src/VsHelpers.cs
+++ b/src/VsHelpers.cs
@@ -21,16 +21,41 @@ namespace MadsKristensen.OpenCommandLine
 
             Window2 window = dte.ActiveWindow as Window2;
 
-            // If Solution Explorer isn't active but document is, then use the document's containing project
-            if (window != null && window.Type == vsWindowType.vsWindowTypeDocument)
+            if (window != null)
             {
-                Document doc = dte.ActiveDocument;
-                if (doc != null && !string.IsNullOrEmpty(doc.FullName))
+                if(window.Type == vsWindowType.vsWindowTypeDocument)
                 {
-                    ProjectItem item = dte.Solution.FindProjectItem(doc.FullName);
+                    // if a document is active, use the document's containing project
+                    Document doc = dte.ActiveDocument;
+                    if (doc != null && !string.IsNullOrEmpty(doc.FullName))
+                    {
+                        ProjectItem item = dte.Solution.FindProjectItem(doc.FullName);
 
-                    if (item != null && item.ContainingProject != null && !string.IsNullOrEmpty(item.ContainingProject.FullName))
-                        return item.ContainingProject.Properties.Item("FullPath").Value.ToString();
+                        if (item != null && item.ContainingProject != null && !string.IsNullOrEmpty(item.ContainingProject.FullName))
+                            return item.ContainingProject.Properties.Item("FullPath").Value.ToString();
+                    }
+                }
+                else if(window.Type == vsWindowType.vsWindowTypeSolutionExplorer)
+                {
+                    // if solution explorer is active, use the path of the first selected item
+                    UIHierarchy hierarchy = window.Object as UIHierarchy;
+                    if (hierarchy != null && hierarchy.SelectedItems != null)
+                    {
+                        UIHierarchyItem[] hierarchyItems = hierarchy.SelectedItems as UIHierarchyItem[];
+                        if(hierarchyItems != null && hierarchyItems.Length > 0)
+                        {
+                            UIHierarchyItem hierarchyItem = hierarchyItems[0] as UIHierarchyItem;
+                            if(hierarchyItem != null)
+                            {
+                                ProjectItem projectItem = hierarchyItem.Object as ProjectItem;
+                                if (projectItem != null && projectItem.FileCount > 0)
+                                {
+                                    string file = projectItem.FileNames[0];
+                                    return Path.GetDirectoryName(file);
+                                }
+                            }
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
Hi Mads,

I would like to propose the following changes to this awesome extension. I use it daily and our work solutions are made up of multiple project hierarchies. This change:
* allows you to right-click on a number of item types in solution explorer, such as folders and files
* sets the working directory to the path of the selected item

Can you please review? I would love to hear your thoughts on this change.