### PR TITLE
New command  'open cmd in output'

### DIFF
--- a/src/OpenCommandLine/Helpers/VsHelpers.cs
+++ b/src/OpenCommandLine/Helpers/VsHelpers.cs
@@ -48,26 +48,15 @@ namespace MadsKristensen.OpenCommandLine
                 else if (window.Type == vsWindowType.vsWindowTypeSolutionExplorer)
                 {
                     // if solution explorer is active, use the path of the first selected item
-                    UIHierarchy hierarchy = window.Object as UIHierarchy;
-                    if (hierarchy != null && hierarchy.SelectedItems != null)
+                    var hierarchy = window.Object as UIHierarchy;
+                    var projectItem = GetSelectedProjectItem(hierarchy);
+                    if (projectItem != null && projectItem.FileCount > 0)
                     {
-                        UIHierarchyItem[] hierarchyItems = hierarchy.SelectedItems as UIHierarchyItem[];
-                        if (hierarchyItems != null && hierarchyItems.Length > 0)
-                        {
-                            UIHierarchyItem hierarchyItem = hierarchyItems[0] as UIHierarchyItem;
-                            if (hierarchyItem != null)
-                            {
-                                ProjectItem projectItem = hierarchyItem.Object as ProjectItem;
-                                if (projectItem != null && projectItem.FileCount > 0)
-                                {
-                                    if (Directory.Exists(projectItem.FileNames[1]))
-                                        return projectItem.FileNames[1];
+                        if (Directory.Exists(projectItem.FileNames[1]))
+                            return projectItem.FileNames[1];
 
-                                    if (IsValidFileName(projectItem.FileNames[1]))
-                                        return Path.GetDirectoryName(projectItem.FileNames[1]);
-                                }
-                            }
-                        }
+                        if (IsValidFileName(projectItem.FileNames[1]))
+                            return Path.GetDirectoryName(projectItem.FileNames[1]);
                     }
                 }
             }
@@ -137,6 +126,90 @@ namespace MadsKristensen.OpenCommandLine
             return null;
         }
 
+        private static UIHierarchyItem GetSelectedHierarchyItem(UIHierarchy hierarchy)
+        {
+            var hierarchyItems = hierarchy?.SelectedItems as UIHierarchyItem[];
+            if (hierarchyItems != null && hierarchyItems.Length > 0)
+            {
+                return hierarchyItems[0];
+            }
+            return null;
+        }
+
+        private static ProjectItem GetSelectedProjectItem(UIHierarchy hierarchy)
+        {
+            var hierarchyItem = GetSelectedHierarchyItem(hierarchy);
+            return hierarchyItem?.Object as ProjectItem;
+        }
+
+        public static string GetOutputPath(DTE2 dte)
+        {
+            var project = GetSelectedProject(dte);
+            if (project == null) return null;
+
+            // ConfigurationManager is null for virtual folder in solution
+            var activeConfigurationProperties = project.ConfigurationManager?.ActiveConfiguration.Properties;
+            var outputPath = activeConfigurationProperties?.Item("OutputPath").Value.ToString();
+
+            // e.g. Python project (opening a folder where the startup file will be better?)
+            if (outputPath == null) return null;
+
+            // C++ project - always
+            // C#/JavaScript/etc project with absolute path in 'Output path'
+            if (Path.IsPathRooted(outputPath))
+            {
+                return outputPath;
+            }
+
+            // C#/JavavScript/etc project with relative path in 'Output path'
+            try
+            {
+                var fullPathObject = project.Properties.Item("FullPath");
+                if (fullPathObject != null)
+                {
+                    var fullPath = fullPathObject.Value.ToString();
+                    // e.g. JavaScript - fullPath is path to project file
+                    if (File.Exists(fullPath)) // maybe FileAttributes?
+                    {
+                        fullPath = Path.GetDirectoryName(fullPath);
+                    }
+                    var outputDir = Path.Combine(fullPath, outputPath);
+                    return outputDir = Path.GetFullPath(outputDir);
+                }
+            }
+            catch (ArgumentException)
+            { }
+
+            return null;
+        }
+
+        private static Project GetSelectedProject(DTE2 dte)
+        {
+            Window2 window = dte.ActiveWindow as Window2;
+
+            if (window != null)
+            {
+                if (window.Type == vsWindowType.vsWindowTypeDocument)
+                {
+                    return dte.ActiveDocument?.ProjectItem?.ContainingProject;
+                }
+
+                if (window.Type == vsWindowType.vsWindowTypeSolutionExplorer)
+                {
+                    var hierarchy = window.Object as UIHierarchy;
+                    var hierarchyItem = GetSelectedHierarchyItem(hierarchy);
+                    var project = hierarchyItem?.Object as Project;
+                    if (project != null)
+                    {
+                        return project;
+                    }
+                    // e.g. file/virtual foler in project
+                    var projectItem = hierarchyItem?.Object as ProjectItem;
+                    return projectItem?.ContainingProject;
+                }
+            }
+            return null;
+        }
 
         public static string GetInstallDirectory(IServiceProvider serviceProvider)
         {

--- a/src/OpenCommandLine/Helpers/VsHelpers.cs
+++ b/src/OpenCommandLine/Helpers/VsHelpers.cs
@@ -149,6 +149,12 @@ namespace MadsKristensen.OpenCommandLine
 
             // ConfigurationManager is null for virtual folder in solution
             var activeConfigurationProperties = project.ConfigurationManager?.ActiveConfiguration.Properties;
+
+            // TODO: this is a bug in VS2017
+            // https://developercommunity.visualstudio.com/content/problem/44682/activeconfigurationproperties-returns-null.html
+            // I don't want to use VCProject because every version of VS reqiures a corresponding version file in reference
+            if (activeConfigurationProperties == null) return null;
+
             var outputPath = activeConfigurationProperties?.Item("OutputPath").Value.ToString();
 
             // e.g. Python project (opening a folder where the startup file will be better?)

--- a/src/OpenCommandLine/Helpers/VsHelpers.cs
+++ b/src/OpenCommandLine/Helpers/VsHelpers.cs
@@ -150,15 +150,15 @@ namespace MadsKristensen.OpenCommandLine
             // ConfigurationManager is null for virtual folder in solution
             var activeConfigurationProperties = project.ConfigurationManager?.ActiveConfiguration.Properties;
 
+            // e.g. Python project
+            //
             // TODO: this is a bug in VS2017
             // https://developercommunity.visualstudio.com/content/problem/44682/activeconfigurationproperties-returns-null.html
             // I don't want to use VCProject because every version of VS reqiures a corresponding version file in reference
+            //
             if (activeConfigurationProperties == null) return null;
 
-            var outputPath = activeConfigurationProperties?.Item("OutputPath").Value.ToString();
-
-            // e.g. Python project (opening a folder where the startup file will be better?)
-            if (outputPath == null) return null;
+            var outputPath = activeConfigurationProperties.Item("OutputPath").Value.ToString();
 
             // C++ project - always
             // C#/JavaScript/etc project with absolute path in 'Output path'

--- a/src/OpenCommandLine/Helpers/VsHelpers.cs
+++ b/src/OpenCommandLine/Helpers/VsHelpers.cs
@@ -147,10 +147,16 @@ namespace MadsKristensen.OpenCommandLine
             var project = GetSelectedProject(dte);
             if (project == null) return null;
 
+            if (project.Kind == VsProjectKindPython)
+            {
+                var startupFile = project.Properties.Item("StartupFile").Value.ToString();
+                return Path.GetDirectoryName(startupFile);
+            }
+
             // ConfigurationManager is null for virtual folder in solution
             var activeConfigurationProperties = project.ConfigurationManager?.ActiveConfiguration.Properties;
 
-            // e.g. Python project
+            // Unknow 'custom' project like Python etc.
             //
             // TODO: this is a bug in VS2017
             // https://developercommunity.visualstudio.com/content/problem/44682/activeconfigurationproperties-returns-null.html
@@ -289,5 +295,7 @@ namespace MadsKristensen.OpenCommandLine
             var configuration2 = dte.Solution.SolutionBuild.ActiveConfiguration as SolutionConfiguration2;
             return configuration2 != null ? configuration2.PlatformName : null;
         }
+
+        private static string VsProjectKindPython = "{888888a0-9f3d-457c-b088-3a5042f75d52}";
     }
 }

--- a/src/OpenCommandLine/Helpers/VsHelpers.cs
+++ b/src/OpenCommandLine/Helpers/VsHelpers.cs
@@ -202,7 +202,7 @@ namespace MadsKristensen.OpenCommandLine
 
         public static string GetSolutionConfigurationName(DTE2 dte)
         {
-            return dte.Solution.SolutionBuild.ActiveConfiguration.Name;
+            return dte.Solution.SolutionBuild.ActiveConfiguration?.Name;
         }
 
         public static string GetSolutionConfigurationPlatformName(DTE2 dte)

--- a/src/OpenCommandLine/OpenCommandLine.cs
+++ b/src/OpenCommandLine/OpenCommandLine.cs
@@ -34,6 +34,7 @@ namespace MadsKristensen.OpenCommandLine
         public const int cmdidOpenPowershell = 0x0300;
         public const int cmdidOpenOptions = 0x0400;
         public const int cmdExecuteCmd = 0x0500;
+        public const int cmdidOpenCmdInOutput = 0x0600;
         public const int @default = 0x0001;
         public const int powershell = 0x0002;
         public const int cmd = 0x0003;

--- a/src/OpenCommandLine/OpenCommandLine.vsct
+++ b/src/OpenCommandLine/OpenCommandLine.vsct
@@ -45,7 +45,7 @@
               <Icon guid="guidImages" id="cmd" />
               <Strings>
                 <CommandName>Open Command Line In Output</CommandName>
-                <ButtonText>CMD In Output</ButtonText>
+                <ButtonText>Cmd In Output</ButtonText>
               </Strings>
             </Button>
             <Button guid="guidOpenCommandLineCmdSet" id="cmdidOpenCmd" priority="0x0100" type="Button">

--- a/src/OpenCommandLine/OpenCommandLine.vsct
+++ b/src/OpenCommandLine/OpenCommandLine.vsct
@@ -40,6 +40,14 @@
                     <ButtonText>Default</ButtonText>
                 </Strings>
             </Button>
+            <Button guid="guidOpenCommandLineCmdSet" id="cmdidOpenCmdInOutput" priority="0x0100" type="Button">
+              <Parent guid="guidOpenCommandLineCmdSet" id="DefaultMenuGroup" />
+              <Icon guid="guidImages" id="cmd" />
+              <Strings>
+                <CommandName>Open Command Line In Output</CommandName>
+                <ButtonText>CMD In Output</ButtonText>
+              </Strings>
+            </Button>
             <Button guid="guidOpenCommandLineCmdSet" id="cmdidOpenCmd" priority="0x0100" type="Button">
                 <Parent guid="guidOpenCommandLineCmdSet" id="DefaultMenuGroup" />
                 <Icon guid="guidImages" id="cmd" />
@@ -85,6 +93,7 @@
         <KeyBinding guid="guidOpenCommandLineCmdSet" id="cmdExecuteCmd" mod1="Alt Shift" key1="5" editor="guidVSStd97"/>
         <KeyBinding guid="guidOpenCommandLineCmdSet" id="cmdidOpenCmd" mod1="Alt Shift" key1="VK_OEM_COMMA" editor="guidVSStd97"/>
         <KeyBinding guid="guidOpenCommandLineCmdSet" id="cmdidOpenPowershell" mod1="Alt Shift" key1="VK_OEM_PERIOD" editor="guidVSStd97"/>
+        <KeyBinding guid="guidOpenCommandLineCmdSet" id="cmdidOpenCmdInOutput" mod1="Alt Shift" key1="VK_SPACE" editor="guidVSStd97"/>
     </KeyBindings>
 
     <CommandPlacements>
@@ -114,6 +123,7 @@
             <IDSymbol name="cmdidOpenPowershell" value="0x0300" />
             <IDSymbol name="cmdidOpenOptions" value="0x0400" />
             <IDSymbol name="cmdExecuteCmd" value="0x0500" />
+            <IDSymbol name="cmdidOpenCmdInOutput" value="0x0600" />
         </GuidSymbol>
 
         <GuidSymbol name="guidImages" value="{bc10dceb-1833-4dac-bc42-286a81241664}" >

--- a/src/OpenCommandLine/OpenCommandLinePackage.cs
+++ b/src/OpenCommandLine/OpenCommandLinePackage.cs
@@ -50,6 +50,10 @@ namespace MadsKristensen.OpenCommandLine
             OleMenuCommand exeItem = new OleMenuCommand(ExecuteFile, cmdExe);
             exeItem.BeforeQueryStatus += BeforeExeQuery;
             mcs.AddCommand(exeItem);
+            
+            CommandID cmdCmdInOutput = new CommandID(PackageGuids.guidOpenCommandLineCmdSet, PackageIds.cmdidOpenCmdInOutput);
+            MenuCommand cmdInOutput = new MenuCommand(OpenCmdInOutput, cmdCmdInOutput);
+            mcs.AddCommand( cmdInOutput );
         }
 
         void BeforeExeQuery(object sender, EventArgs e)
@@ -125,6 +129,10 @@ namespace MadsKristensen.OpenCommandLine
         private void OpenPowershell(object sender, EventArgs e)
         {
             SetupProcess("powershell.exe", "-ExecutionPolicy Bypass -NoExit");
+        }
+
+        private void OpenCmdInOutput(object sender, EventArgs e)
+        {
         }
 
         private void SetupProcess(string command, string arguments)

--- a/src/OpenCommandLine/OpenCommandLinePackage.cs
+++ b/src/OpenCommandLine/OpenCommandLinePackage.cs
@@ -50,10 +50,10 @@ namespace MadsKristensen.OpenCommandLine
             OleMenuCommand exeItem = new OleMenuCommand(ExecuteFile, cmdExe);
             exeItem.BeforeQueryStatus += BeforeExeQuery;
             mcs.AddCommand(exeItem);
-            
+
             CommandID cmdCmdInOutput = new CommandID(PackageGuids.guidOpenCommandLineCmdSet, PackageIds.cmdidOpenCmdInOutput);
             MenuCommand cmdInOutput = new MenuCommand(OpenCmdInOutput, cmdCmdInOutput);
-            mcs.AddCommand( cmdInOutput );
+            mcs.AddCommand(cmdInOutput);
         }
 
         void BeforeExeQuery(object sender, EventArgs e)
@@ -103,10 +103,9 @@ namespace MadsKristensen.OpenCommandLine
             button.Text = options.FriendlyName;
         }
 
-        private void OpenCustom(object sender, EventArgs e)
+        private void OpenCustomInFolder(string folder)
         {
             Options options = GetDialogPage(typeof(Options)) as Options;
-            string folder = VsHelpers.GetFolderPath(options, _dte);
             string arguments = (options.Arguments ?? string.Empty).Replace("%folder%", folder);
 
             string confName = VsHelpers.GetSolutionConfigurationName(_dte);
@@ -116,6 +115,14 @@ namespace MadsKristensen.OpenCommandLine
             arguments = arguments.Replace("%platform%", confPlatform);
 
             StartProcess(folder, options.Command, arguments);
+        }
+
+        private void OpenCustom(object sender, EventArgs e)
+        {
+            Options options = GetDialogPage(typeof(Options)) as Options;
+            string folder = VsHelpers.GetFolderPath(options, _dte);
+
+            OpenCustomInFolder(folder);
         }
 
         private void OpenCmd(object sender, EventArgs e)
@@ -133,6 +140,10 @@ namespace MadsKristensen.OpenCommandLine
 
         private void OpenCmdInOutput(object sender, EventArgs e)
         {
+            string outDirectory = "";
+            if (!Directory.Exists(outDirectory)) return;
+
+            OpenCustomInFolder(outDirectory);
         }
 
         private void SetupProcess(string command, string arguments)

--- a/src/OpenCommandLine/OpenCommandLinePackage.cs
+++ b/src/OpenCommandLine/OpenCommandLinePackage.cs
@@ -140,7 +140,7 @@ namespace MadsKristensen.OpenCommandLine
 
         private void OpenCmdInOutput(object sender, EventArgs e)
         {
-            string outDirectory = "";
+            string outDirectory = VsHelpers.GetOutputPath(_dte);
             if (!Directory.Exists(outDirectory)) return;
 
             OpenCustomInFolder(outDirectory);


### PR DESCRIPTION
Hi
New command 'open cmd in ouput' - it opens cmd in output folder.
This is very useful for projects where the output is outside the solution.
For projects like 'python' it opens folder where the 'startup file' is.