### PR TITLE
Mention Windows Terminal in description and tags

### DIFF
--- a/src/Package/source.extension.vsixmanifest
+++ b/src/Package/source.extension.vsixmanifest
@@ -3,12 +3,12 @@
   <Metadata>
     <Identity Id="f4ab1e64-5d35-4f06-bad9-bf414f4b3bbb" Version="2.1" Language="en-US" Publisher="Mads Kristensen" />
     <DisplayName>Open Command Line</DisplayName>
-    <Description xml:space="preserve">Opens a command line at the root of the project. Support for all consoles such as CMD, PowerShell, Bash etc. Provides syntax highlighting, Intellisense and execution of .cmd and .bat files.</Description>
+    <Description xml:space="preserve">Opens a command line at the root of the project. Support for all consoles such as CMD, PowerShell, Windows Terminal, Bash etc. Provides syntax highlighting, Intellisense and execution of .cmd and .bat files.</Description>
     <MoreInfo>https://github.com/madskristensen/OpenCommandLine</MoreInfo>
     <License>Resources\LICENSE</License>
     <Icon>Resources\icon.png</Icon>
     <PreviewImage>Resources\preview.png</PreviewImage>
-    <Tags>Solution Explorer, cmd, powershell, bash, post-git, cmder, prompt, console, conemu</Tags>
+    <Tags>Solution Explorer, cmd, powershell, bash, post-git, cmder, prompt, console, conemu, Windows Terminal</Tags>
   </Metadata>
   <Installation>
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="12.0" />


### PR DESCRIPTION
Since this shows up in the Marketplace and Visual Studio, it helps users discover the add-in.