### PR TITLE
Support for VS2022 on ARM64

### DIFF
--- a/src/OpenCommandLine/OpenCommandLine.csproj
+++ b/src/OpenCommandLine/OpenCommandLine.csproj
@@ -119,10 +119,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.0.0-previews-4-31709-430</Version>
+      <Version>17.7.37357</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.5232</Version>
+      <Version>17.7.2196</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/OpenCommandLine/source.extension.vsixmanifest
+++ b/src/OpenCommandLine/source.extension.vsixmanifest
@@ -1,24 +1,27 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="a7b534ac-949b-40f9-a795-deb511823941" Version="2.5.999" Language="en-US" Publisher="Mads Kristensen" />
-    <DisplayName>Open Command Line</DisplayName>
-    <Description xml:space="preserve">Opens a command line at the root of the project. Support for all consoles such as CMD, PowerShell, Bash etc. Provides syntax highlighting, Intellisense and execution of .cmd and .bat files.</Description>
-    <MoreInfo>https://github.com/madskristensen/OpenCommandLine</MoreInfo>
-    <License>Resources\LICENSE</License>
-    <Icon>Resources\icon.png</Icon>
-    <PreviewImage>Resources\preview.png</PreviewImage>
-    <Tags>Solution Explorer, cmd, powershell, bash, post-git, cmder, prompt, console, conemu</Tags>
-  </Metadata>
-  <Installation InstalledByMsi="false">
-    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-  </Installation>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="a7b534ac-949b-40f9-a795-deb511823941" Version="2.5.999" Language="en-US" Publisher="Mads Kristensen" />
+        <DisplayName>Open Command Line</DisplayName>
+        <Description xml:space="preserve">Opens a command line at the root of the project. Support for all consoles such as CMD, PowerShell, Bash etc. Provides syntax highlighting, Intellisense and execution of .cmd and .bat files.</Description>
+        <MoreInfo>https://github.com/madskristensen/OpenCommandLine</MoreInfo>
+        <License>Resources\LICENSE</License>
+        <Icon>Resources\icon.png</Icon>
+        <PreviewImage>Resources\preview.png</PreviewImage>
+        <Tags>Solution Explorer, cmd, powershell, bash, post-git, cmder, prompt, console, conemu</Tags>
+    </Metadata>
+    <Installation InstalledByMsi="false">
+        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[17.0,18.0)">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
+    </Installation>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
Hi,
since Windows on ARM and VS2022 on ARM are now more in mainstream, it could be nice to add support. I tried and it was easy :) Apart from ProductArchitecture in the manifest, the build tools and SDK version have been bumped for ARM64 support.

I have been using my build of this extension for some time and it seems to be working properly.

Fixes #98 